### PR TITLE
Add redis-server

### DIFF
--- a/base/debian-requirements.txt
+++ b/base/debian-requirements.txt
@@ -37,6 +37,7 @@ graphviz-dev
 
 # redis
 tcl
+redis-server
 
 # required to translate
 gettext


### PR DESCRIPTION
As coded, the Locate task requires redis server to be installed to transfer large objects (see contraxsuite_services/apps/common/advancedcelery/transfer.py).  On a clean 16.04 LTS, this will ensure redis-server is installed.